### PR TITLE
Push files to covid-data

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -45,3 +45,15 @@ jobs:
     # Commit changes 
     #python scripts/livraisons.py
     - uses: stefanzweifel/git-auto-commit-action@v4
+    
+    # Push files to covid-data
+    - uses: dmnemec/copy_file_to_another_repo_action@v1.0.4
+      env:
+        API_TOKEN_GITHUB: ${{ secrets.API_REPO_TOKEN }}
+      with:
+        source_file: 'data/output/*'
+        destination_repo: 'CovidTrackerFr/covid-data'
+        destination_folder: 'json/vaccins'
+        destination_branch: 'main'
+        user_email: 'TON_EMAIL'
+        user_name: 'rozierguillaume'


### PR DESCRIPTION
Avant d'accepter cette PR, il faut créer un secret dans le dépôt vaccintracker avec un token pour écrire dans CovidTrackerFr/covid-data ( https://github.com/settings/tokens ) et mettre ton email correspondant au compte rozierguillaume (que tu peux mettre dans un secret aussi pour éviter que ça soit glané).