### PR TITLE
Updated data pull schedule

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -3,7 +3,7 @@ name: Python Scripts
 # Controls when the action will run. 
 on:
   schedule:
-  - cron: "17 19 * * *" # UTC time (-1 en hiver et -2 en été)
+  - cron: "30 16 * * *" # UTC time (-1 en hiver et -2 en été)
   #push:
     #branches: [ main ]
   #pull_request:


### PR DESCRIPTION
Vaccine data seems to be updated at 5:25pm now, so I changed the CI schedule.

See: https://www.data.gouv.fr/fr/datasets/donnees-relatives-aux-personnes-vaccinees-contre-la-covid-19-1/